### PR TITLE
Add logging information for events.

### DIFF
--- a/libraries/nomad_job.rb
+++ b/libraries/nomad_job.rb
@@ -45,10 +45,10 @@ class NomadJob < Inspec.resource(1)
     allocations.each do |allocation|
         task_states = allocation['TaskStates']
         task_states.each do |task_name, task_state|
-            puts "Events for task #{task_name} in allocation #{allocation['ID']}:"
+            puts " Events for task #{task_name} in allocation #{allocation['ID']}:"
             events = task_state['Events']
             events.each do |event|
-                puts "Event #{event['Type']} with message: #{event['DriverMessage']}"
+                puts "  Event '#{event['Type']}' with message: #{event['DriverMessage']}"
             end
         end
     end

--- a/libraries/nomad_job.rb
+++ b/libraries/nomad_job.rb
@@ -4,6 +4,7 @@ class NomadJob < Inspec.resource(1)
   example "
     describe nomad_job('http://localhost:4646', 'test_job') do
       it { should be_running }
+      its { status }
     end
   "
 
@@ -20,8 +21,13 @@ class NomadJob < Inspec.resource(1)
   end
 
   def running?
-    job = http_json("#{@url}/v1/job/#{@job_name}")
-    job['Status'] == 'running'
+    status == 'running'
+  end
+
+  def status
+    job = get_job
+    print_allocation_logs(job['ID'])
+    job['Status']
   end
 
   def to_s
@@ -29,6 +35,24 @@ class NomadJob < Inspec.resource(1)
   end
 
   private
+
+  def get_job
+    http_json("#{@url}/v1/job/#{@job_name}")
+  end
+
+  def print_allocation_logs(job_id)
+    allocations = http_json("#{@url}/v1/job/#{job_id}/allocations")
+    allocations.each do |allocation|
+        task_states = allocation['TaskStates']
+        task_states.each do |task_name, task_state|
+            puts "Events for task #{task_name} in allocation #{allocation['ID']}:"
+            events = task_state['Events']
+            events.each do |event|
+                puts "Event #{event['Type']} with message: #{event['DriverMessage']}"
+            end
+        end
+    end
+  end
 
   def http_json(url)
     query = inspec.http(url)

--- a/libraries/nomad_job.rb
+++ b/libraries/nomad_job.rb
@@ -4,7 +4,7 @@ class NomadJob < Inspec.resource(1)
   example "
     describe nomad_job('http://localhost:4646', 'test_job') do
       it { should be_running }
-      its { status }
+      its('status') { should eq 'running' }
     end
   "
 


### PR DESCRIPTION
Add message of events to output during Inspec tests. This can help debugging when the job is not running.