### PR TITLE
Add custom resource for AWS Route Table Association.

### DIFF
--- a/libraries/aws_route_table_association.rb
+++ b/libraries/aws_route_table_association.rb
@@ -2,12 +2,9 @@ class AWSRouteTableAssociation < Inspec.resource(1)
   name 'aws_route_table_association'
   desc 'Test the configuration of a class AWS Route Table Association'
   example "
-    describe aws_vpc_endpoint('rtb-1234', 'rtbassoc-1234') do
+    describe aws_route_table_association('rtb-1234', 'rtbassoc-1234') do
       it { should exist }
-      it { should be_main }
-      its('id') { should eq 'rtbassoc-1234' }
-      its('subnet_id') { should eq 'subnet-1234' }
-      its('route_table_id') { should eq 'rtb-1234' }
+      its('subnet_id') { should be_in public_subnets }
     end
   "
 
@@ -50,6 +47,7 @@ class AWSRouteTableAssociation < Inspec.resource(1)
     associations.each do |assoc|
       if assoc['route_table_association_id'] == route_table_association_id
         association = assoc
+        break
       end
     end
     association

--- a/libraries/aws_route_table_association.rb
+++ b/libraries/aws_route_table_association.rb
@@ -8,9 +8,9 @@ class AWSRouteTableAssociation < Inspec.resource(1)
     end
   "
 
-  def initialize(route_table_id, route_table_association_id)
+  def initialize(route_table_association_id)
     @route_table_association_id = route_table_association_id
-    @route_table_association = get_route_table_association(route_table_id, route_table_association_id)
+    @route_table_association = get_route_table_association(route_table_association_id)
   end
 
   def to_s
@@ -39,15 +39,17 @@ class AWSRouteTableAssociation < Inspec.resource(1)
 
   private
 
-  def get_route_table_association(route_table_id, route_table_association_id)
+  def get_route_table_association(route_table_association_id)
     association = nil
     ec2 = Aws::EC2::Client.new
-    route_table = ec2.describe_route_tables(route_table_ids: [route_table_id]).route_tables[0]
-    associations = route_table.associations
-    associations.each do |assoc|
-      if assoc['route_table_association_id'] == route_table_association_id
-        association = assoc
-        break
+    route_tables = ec2.describe_route_tables().route_tables
+    route_tables.each do |route_table|
+      associations = route_table.associations
+      associations.each do |assoc|
+        if assoc['route_table_association_id'] == route_table_association_id
+          association = assoc
+          break
+        end
       end
     end
     association

--- a/libraries/aws_route_table_association.rb
+++ b/libraries/aws_route_table_association.rb
@@ -1,0 +1,57 @@
+class AWSRouteTableAssociation < Inspec.resource(1)
+  name 'aws_route_table_association'
+  desc 'Test the configuration of a class AWS Route Table Association'
+  example "
+    describe aws_vpc_endpoint('rtb-1234', 'rtbassoc-1234') do
+      it { should exist }
+      it { should be_main }
+      its('id') { should eq 'rtbassoc-1234' }
+      its('subnet_id') { should eq 'subnet-1234' }
+      its('route_table_id') { should eq 'rtb-1234' }
+    end
+  "
+
+  def initialize(route_table_id, route_table_association_id)
+    @route_table_association_id = route_table_association_id
+    @route_table_association = get_route_table_association(route_table_id, route_table_association_id)
+  end
+
+  def to_s
+    "Route Table Association #{@route_table_association_id}"
+  end
+
+  def exists?
+    @route_table_association != nil
+  end
+
+  def main?
+    @vpc_endpoint.main
+  end
+
+  def id
+    @route_table_association.id
+  end
+
+  def subnet_id
+    @route_table_association.subnet_id
+  end
+
+  def route_table_id
+    @route_table_association.route_table_id
+  end
+
+  private
+
+  def get_route_table_association(route_table_id, route_table_association_id)
+    association = nil
+    ec2 = Aws::EC2::Client.new
+    route_table = ec2.describe_route_tables(route_table_ids: [route_table_id]).route_tables[0]
+    associations = route_table.associations
+    associations.each do |assoc|
+      if assoc['route_table_association_id'] == route_table_association_id
+        association = assoc
+      end
+    end
+    association
+  end
+end

--- a/libraries/aws_route_table_association.rb
+++ b/libraries/aws_route_table_association.rb
@@ -2,7 +2,7 @@ class AWSRouteTableAssociation < Inspec.resource(1)
   name 'aws_route_table_association'
   desc 'Test the configuration of a class AWS Route Table Association'
   example "
-    describe aws_route_table_association('rtb-1234', 'rtbassoc-1234') do
+    describe aws_route_table_association('rtbassoc-1234') do
       it { should exist }
       its('subnet_id') { should be_in public_subnets }
     end


### PR DESCRIPTION
Modelled after the [terraform resource](https://www.terraform.io/docs/providers/aws/r/route_table_association.html).